### PR TITLE
Remove german word for lap (Runde) from german msgstr for estimated…

### DIFF
--- a/src/translations/de/de.po
+++ b/src/translations/de/de.po
@@ -190,7 +190,7 @@ msgstr "Vorauss. Position"
 #. {_('Est. Time')}:{' '}
 #. <span className="mono">
 msgid "Est. Time"
-msgstr "Vorauss. Rundenzeit"
+msgstr "Vorauss. Zeit"
 
 #. ./src/components/app/app.tsx:129:129
 #. estimatedLapTime: {


### PR DESCRIPTION
…time (not estimated lap time).